### PR TITLE
Add 'Test new order' endpoint

### DIFF
--- a/lib/binance/client/rest/account_api.rb
+++ b/lib/binance/client/rest/account_api.rb
@@ -26,6 +26,10 @@ module Binance
           request :account, :post, 'order', options
         end
 
+        def create_test_order(options)
+          request :account, :post, 'order/test', options
+        end
+
         def query_order(options)
           request :account, :get, 'order', options
         end


### PR DESCRIPTION
Hey @craysiii, thanks for making this gem. I noticed you were missing the `Test new order` endpoint from the [Binance Public API](https://www.binance.com/restapipub.html#user-content-account-endpoints). I added it since it makes testing this gem a lot easier.