### PR TITLE
Allow rest.open_orders without params

### DIFF
--- a/lib/binance/client/rest/account_api.rb
+++ b/lib/binance/client/rest/account_api.rb
@@ -114,7 +114,7 @@ module Binance
         #                 milliseconds (optional).
         #
         # Returns a Hash with the request response
-        def open_orders(options)
+        def open_orders(**options)
           request :signed, :get, :openOrders, options
         end
 


### PR DESCRIPTION
Currently it has to be called with `rest.open_orders({})` or you will get `ArgumentError: wrong number of arguments (given 0, expected 1)`