### PR TITLE
Add Binance::Client::REST::HTTP2

### DIFF
--- a/binance.gemspec
+++ b/binance.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'faraday', '~> 0.12'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.12'
   spec.add_runtime_dependency 'faye-websocket', '~> 0.10'
+  spec.add_runtime_dependency 'net-http2', '~> 0.16'
 end

--- a/lib/binance.rb
+++ b/lib/binance.rb
@@ -1,4 +1,5 @@
 
 require 'binance/version'
 require 'binance/client/rest'
+require 'binance/client/rest/http2'
 require 'binance/client/websocket'

--- a/lib/binance/client/rest/http2.rb
+++ b/lib/binance/client/rest/http2.rb
@@ -1,0 +1,82 @@
+require 'net-http2'
+
+require_relative '../rest'
+require_relative 'signed_full_path'
+
+
+module Binance
+  module Client
+    # Public: Client with methods mirroring the Binance REST APIs
+    class REST::HTTP2
+
+      include Binance::Client::REST::PublicAPI
+      include Binance::Client::REST::AccountAPI
+      include Binance::Client::REST::WithdrawAPI
+
+      # Public: Initialize a REST Client
+      #
+      # :api_key    - The String API key to authenticate
+      # :secret_key - The String secret key to authenticate
+      def initialize(api_key: nil, secret_key: nil)
+        @api_key = api_key
+        @secret_key = secret_key
+      end
+
+      def call_async(api_request)
+        client.call_async(api_request)
+      end
+
+      def call(api_request)
+        client.call(api_request.method, api_request.full_path).body
+      end
+
+      private
+
+      def client
+        @client ||= NetHttp2::Client.new(Binance::Client::REST::BASE_URL)
+      end
+
+      def request(api, http_method, api_method, params = {})
+        case api
+        when :public, :verified, :signed
+          request_method = api
+          path = '/api/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
+        when :withdraw
+          request_method = :signed
+          path = '/wapi/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
+        when :public_withdraw
+          request_method = :public
+          path = '/wapi/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
+        else
+          raise TypeError, "Unknown request endpoint: #{api.inspect}"
+        end
+        send(request_method, http_method, path, params)
+      end
+
+      def public(http_method, path, params = {})
+        client.prepare_request(http_method, path, params: params)
+      end
+
+      def verified(http_method, path, params = {})
+        client.prepare_request(
+          http_method, path,
+          headers: { 'X-MBX-APIKEY' => @api_key },
+          params: params
+        )
+      end
+
+      def signed(http_method, path, params = {})
+        verified_request.extend(Binance::Client::REST::SignedFullPath).tap do |request|
+          request.set_secret(@secret_key)
+        end
+      end
+
+      def timestamped(http_method, path, params = {})
+        signed_request(
+          http_method, path,
+          params.merge('timestamp' => DateTime.now.strftime('%Q'))
+        )
+      end
+    end
+  end
+end

--- a/lib/binance/client/rest/http2.rb
+++ b/lib/binance/client/rest/http2.rb
@@ -69,13 +69,13 @@ module Binance
       end
 
       def signed(http_method, path, params = {})
-        verified_request(http_method, path, params).extend(Binance::Client::REST::SignedFullPath).tap do |request|
+        verified(http_method, path, params).extend(Binance::Client::REST::SignedFullPath).tap do |request|
           request.set_secret(@secret_key)
         end
       end
 
       def timestamped(http_method, path, params = {})
-        signed_request(
+        signed(
           http_method, path,
           params.merge('timestamp' => DateTime.now.strftime('%Q'))
         )

--- a/lib/binance/client/rest/http2.rb
+++ b/lib/binance/client/rest/http2.rb
@@ -66,7 +66,7 @@ module Binance
       end
 
       def signed(http_method, path, params = {})
-        verified_request.extend(Binance::Client::REST::SignedFullPath).tap do |request|
+        verified_request(http_method, path, params).extend(Binance::Client::REST::SignedFullPath).tap do |request|
           request.set_secret(@secret_key)
         end
       end

--- a/lib/binance/client/rest/http2.rb
+++ b/lib/binance/client/rest/http2.rb
@@ -38,14 +38,17 @@ module Binance
 
       def request(api, http_method, api_method, params = {})
         case api
-        when :public, :verified, :signed
-          request_method = api
+        when :public
+          request_method = :public
           path = '/api/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
-        when :withdraw
-          request_method = :signed
-          path = '/wapi/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
         when :public_withdraw
           request_method = :public
+          path = '/wapi/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
+        when :verified, :signed
+          request_method = :timestamped
+          path = '/api/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
+        when :withdraw
+          request_method = :timestamped
           path = '/wapi/%s' % Binance::Client::REST::API_ENDPOINTS[api_method]
         else
           raise TypeError, "Unknown request endpoint: #{api.inspect}"

--- a/lib/binance/client/rest/signed_full_path.rb
+++ b/lib/binance/client/rest/signed_full_path.rb
@@ -2,7 +2,7 @@
 module Binance
   module Client
     class REST
-      module SignedFullpath
+      module SignedFullPath
         def set_secret(secret)
           @secret = secret
         end
@@ -11,7 +11,7 @@ module Binance
           path = super
           params = path.split('?', 2).last
           signature = OpenSSL::HMAC.hexdigest(
-            OpenSSL::Digest.new('sha256', @secret, params)
+            OpenSSL::Digest.new('sha256'), @secret, params
           )
           @secret = nil
           path + "&signature=%s" % signature

--- a/lib/binance/client/rest/signed_full_path.rb
+++ b/lib/binance/client/rest/signed_full_path.rb
@@ -1,0 +1,22 @@
+
+module Binance
+  module Client
+    class REST
+      module SignedFullpath
+        def set_secret(secret)
+          @secret = secret
+        end
+
+        def full_path
+          path = super
+          params = path.split('?', 2).last
+          signature = OpenSSL::HMAC.hexdigest(
+            OpenSSL::Digest.new('sha256', @secret, params)
+          )
+          @secret = nil
+          path + "&signature=%s" % signature
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Still quite untested and mostly proof of concept / work in progress.

Adds net-http2 dependency and brings an alternative `Binance::Client::REST::HTTP2` client for you to play with.

This can be used like:

```ruby
rest = Binance::Client::REST::HTTP2.new(api_key: 'xxx', secret_key: 'xyz')
request = rest.klines(symbol: 'XRPBTC', interval: '5m', limit: 10)
request2 = rest.klines(symbol: 'APPCBTC', interval: '5m', limit: 10)

request.on(:body_chunk) do |chunk|
  puts 'xrp: %s' % chunk
end

request2.on(:body_chunk) do |chunk|
  puts 'appc: %s' % chunk
end

rest.call_async(request)
rest.call_async(request2)
```

or in not-so-async manner:

```ruby
rest = Binance::Client::REST::HTTP2.new(api_key: 'xxx', secret_key: 'xyz')
puts 'xrp: %p' % rest.call(rest.klines(symbol: 'XRPBTC', interval: '5m', limit: 10))
```

I haven't done any real benchmarking, but it SEEMS to react quite a lot faster than the regular `Binance::Client::REST` does (especially after the first request)
