### PR TITLE
Add allPrices endpoint, and all_prices method

### DIFF
--- a/lib/binance/client/rest/endpoints.rb
+++ b/lib/binance/client/rest/endpoints.rb
@@ -13,6 +13,7 @@ module Binance
         klines:            'v1/klines',
         twenty_four_hour:  'v1/ticker/24hr',
         price:             'v3/ticker/price',
+        all_prices:        'v3/ticker/allPrices',
         book_ticker:       'v3/ticker/bookTicker',
 
         # Account API Endpoints

--- a/lib/binance/client/rest/methods.rb
+++ b/lib/binance/client/rest/methods.rb
@@ -33,6 +33,9 @@ module Binance
         # #price
         { name: :price, client: :public,
           action: :get, endpoint: :price },
+        # #all_prices
+        { name: :all_prices, client: :public,
+          action: :get, endpoint: :price },
         # #book_ticker
         { name: :book_ticker, client: :public,
           action: :get, endpoint: :book_ticker },


### PR DESCRIPTION
With this endpoint added, #21 can be solved with 2 api calls.

```
def btc_balance
  price_data = $client.all_prices.inject({}) do |hash, data|
    hash.merge(data["symbol"] => data["price"].to_f)
  end
  
  info = $client.account_info(recvWindow: 100000)
  
  btc_value = info["balances"].sum do |balance|
    asset = balance["asset"]
    asset_qty = balance["free"].to_f + balance["locked"].to_f
    
    if asset_qty < 0.00000001
      0.0
    elsif asset == 'BTC'
      asset_qty
    else
      asset_qty * price_data["#{asset}BTC"]
    end
  end
  
  btc_value.round(8)
end
```