### PR TITLE
Remove unused allPrices endpoint

### DIFF
--- a/lib/binance/client/rest/endpoints.rb
+++ b/lib/binance/client/rest/endpoints.rb
@@ -13,7 +13,6 @@ module Binance
         klines:            'v1/klines',
         twenty_four_hour:  'v1/ticker/24hr',
         price:             'v3/ticker/price',
-        all_prices:        'v3/ticker/allPrices',
         book_ticker:       'v3/ticker/bookTicker',
 
         # Account API Endpoints


### PR DESCRIPTION
It seems `/allPrices` is unnecessary. the `/price` endpoint called with no arguments returns all prices.