### PR TITLE
REST client withdraw is able to use a proxy to work with Binance restricted access to trusted IPS on withdrawals api

### DIFF
--- a/lib/binance/client/rest.rb
+++ b/lib/binance/client/rest.rb
@@ -14,11 +14,11 @@ module Binance
       def initialize(api_key: '', secret_key: '',
                      adapter: Faraday.default_adapter, proxy: nil)
         @clients = {}
-        @clients[:public]   = public_client adapter
-        @clients[:verified] = verified_client api_key, adapter
-        @clients[:signed]   = signed_client api_key, secret_key, adapter
+        @clients[:public]   = public_client adapter, proxy
+        @clients[:verified] = verified_client api_key, adapter, proxy
+        @clients[:signed]   = signed_client api_key, secret_key, adapter, proxy
         @clients[:withdraw] = withdraw_client api_key, secret_key, adapter, proxy
-        @clients[:public_withdraw] = public_withdraw_client adapter
+        @clients[:public_withdraw] = public_withdraw_client adapter, proxy
       end
 
       METHODS.each do |method|

--- a/lib/binance/client/rest.rb
+++ b/lib/binance/client/rest.rb
@@ -12,12 +12,12 @@ module Binance
       BASE_URL = 'https://api.binance.com'.freeze
 
       def initialize(api_key: '', secret_key: '',
-                     adapter: Faraday.default_adapter)
+                     adapter: Faraday.default_adapter, proxy: nil)
         @clients = {}
         @clients[:public]   = public_client adapter
         @clients[:verified] = verified_client api_key, adapter
         @clients[:signed]   = signed_client api_key, secret_key, adapter
-        @clients[:withdraw] = withdraw_client api_key, secret_key, adapter
+        @clients[:withdraw] = withdraw_client api_key, secret_key, adapter, proxy
         @clients[:public_withdraw] = public_withdraw_client adapter
       end
 

--- a/lib/binance/client/rest.rb
+++ b/lib/binance/client/rest.rb
@@ -19,6 +19,7 @@ module Binance
         @clients[:signed]   = signed_client api_key, secret_key, adapter, proxy
         @clients[:withdraw] = withdraw_client api_key, secret_key, adapter, proxy
         @clients[:public_withdraw] = public_withdraw_client adapter, proxy
+        @clients[:margin] = margin_client api_key, secret_key, adapter, proxy
       end
 
       METHODS.each do |method|

--- a/lib/binance/client/rest/clients.rb
+++ b/lib/binance/client/rest/clients.rb
@@ -3,24 +3,24 @@ require 'faraday_middleware'
 module Binance
   module Client
     class REST
-      def public_client(adapter)
-        Faraday.new(url: "#{BASE_URL}/api") do |conn|
+      def public_client(adapter, proxy)
+        Faraday.new(url: "#{BASE_URL}/api", proxy: proxy) do |conn|
           conn.request :json
           conn.response :json, content_type: /\bjson$/
           conn.adapter adapter
         end
       end
 
-      def verified_client(api_key, adapter)
-        Faraday.new(url: "#{BASE_URL}/api") do |conn|
+      def verified_client(api_key, adapter, proxy)
+        Faraday.new(url: "#{BASE_URL}/api", proxy: proxy) do |conn|
           conn.response :json, content_type: /\bjson$/
           conn.headers['X-MBX-APIKEY'] = api_key
           conn.adapter adapter
         end
       end
 
-      def signed_client(api_key, secret_key, adapter)
-        Faraday.new(url: "#{BASE_URL}/api") do |conn|
+      def signed_client(api_key, secret_key, adapter, proxy)
+        Faraday.new(url: "#{BASE_URL}/api", proxy: proxy) do |conn|
           conn.request :json
           conn.response :json, content_type: /\bjson$/
           conn.headers['X-MBX-APIKEY'] = api_key
@@ -30,8 +30,8 @@ module Binance
         end
       end
 
-      def public_withdraw_client(adapter)
-        Faraday.new(url: "#{BASE_URL}/wapi") do |conn|
+      def public_withdraw_client(adapter, proxy)
+        Faraday.new(url: "#{BASE_URL}/wapi", proxy: proxy) do |conn|
           conn.request :json
           conn.response :json, content_type: /\bjson$/
           conn.adapter adapter

--- a/lib/binance/client/rest/clients.rb
+++ b/lib/binance/client/rest/clients.rb
@@ -48,6 +48,17 @@ module Binance
           conn.adapter adapter
         end
       end
+
+      def margin_client(api_key, secret_key, adapter, proxy)
+        Faraday.new(url: "#{BASE_URL}/sapi", proxy: proxy) do |conn|
+          conn.request :url_encoded
+          conn.response :json, content_type: /\bjson$/
+          conn.headers['X-MBX-APIKEY'] = api_key
+          conn.use TimestampRequestMiddleware
+          conn.use SignRequestMiddleware, secret_key
+          conn.adapter adapter
+        end
+      end
     end
   end
 end

--- a/lib/binance/client/rest/clients.rb
+++ b/lib/binance/client/rest/clients.rb
@@ -38,8 +38,8 @@ module Binance
         end
       end
 
-      def withdraw_client(api_key, secret_key, adapter)
-        Faraday.new(url: "#{BASE_URL}/wapi") do |conn|
+      def withdraw_client(api_key, secret_key, adapter, proxy)
+        Faraday.new(url: "#{BASE_URL}/wapi", proxy: proxy) do |conn|
           conn.request :url_encoded
           conn.response :json, content_type: /\bjson$/
           conn.headers['X-MBX-APIKEY'] = api_key

--- a/lib/binance/client/rest/endpoints.rb
+++ b/lib/binance/client/rest/endpoints.rb
@@ -32,7 +32,8 @@ module Binance
         account_status:   'v3/accountStatus.html',
         system_status:    'v3/systemStatus.html',
         withdraw_fee:     'v3/withdrawFee.html',
-        dust_log:         'v3/userAssetDribbletLog.html'
+        dust_log:         'v3/userAssetDribbletLog.html',
+        asset_detail:     'v3/assetDetail.html'
       }.freeze
     end
   end

--- a/lib/binance/client/rest/endpoints.rb
+++ b/lib/binance/client/rest/endpoints.rb
@@ -33,7 +33,10 @@ module Binance
         system_status:    'v3/systemStatus.html',
         withdraw_fee:     'v3/withdrawFee.html',
         dust_log:         'v3/userAssetDribbletLog.html',
-        asset_detail:     'v3/assetDetail.html'
+        asset_detail:     'v3/assetDetail.html',
+
+        # Margin API Endpoints
+        get_all:          'v1/capital/config/getall'
       }.freeze
     end
   end

--- a/lib/binance/client/rest/methods.rb
+++ b/lib/binance/client/rest/methods.rb
@@ -99,7 +99,10 @@ module Binance
           action: :get, endpoint: :withdraw_fee },
         # dust_log
         { name: :dust_log, client: :withdraw,
-          action: :get, endpoint: :dust_log }
+          action: :get, endpoint: :dust_log },
+        # asset_detail
+        { name: :asset_detail, client: :withdraw,
+          action: :get, endpoint: :asset_detail }
       ].freeze
     end
   end

--- a/lib/binance/client/rest/methods.rb
+++ b/lib/binance/client/rest/methods.rb
@@ -102,7 +102,11 @@ module Binance
           action: :get, endpoint: :dust_log },
         # asset_detail
         { name: :asset_detail, client: :withdraw,
-          action: :get, endpoint: :asset_detail }
+          action: :get, endpoint: :asset_detail },
+        #get_all
+        { name: :get_all, client: :margin,
+          action: :get, endpoint: :get_all
+        }
       ].freeze
     end
   end

--- a/lib/binance/version.rb
+++ b/lib/binance/version.rb
@@ -1,3 +1,3 @@
 module Binance
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
 end

--- a/lib/binance/version.rb
+++ b/lib/binance/version.rb
@@ -1,3 +1,3 @@
 module Binance
-  VERSION = '1.3.1'.freeze
+  VERSION = '1.4.0'.freeze
 end

--- a/lib/binance/version.rb
+++ b/lib/binance/version.rb
@@ -1,3 +1,3 @@
 module Binance
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
It's specially useful for servers with non-static ips addresses like EC2