### PR TITLE
Fix can't modify frozen String error

### DIFF
--- a/lib/binance/client/rest.rb
+++ b/lib/binance/client/rest.rb
@@ -33,8 +33,8 @@ module Binance
 
       def self.add_query_param(query, key, value)
         query = query.to_s
-        query << '&' unless query.empty?
-        query << "#{Faraday::Utils.escape key}=#{Faraday::Utils.escape value}"
+        query += '&' unless query.empty?
+        query += "#{Faraday::Utils.escape key}=#{Faraday::Utils.escape value}"
       end
 
       def camelize(str)

--- a/lib/binance/client/rest.rb
+++ b/lib/binance/client/rest.rb
@@ -34,7 +34,7 @@ module Binance
       def self.add_query_param(query, key, value)
         query = query.to_s
         query += '&' unless query.empty?
-        query += "#{Faraday::Utils.escape key}=#{Faraday::Utils.escape value}"
+        query + "#{Faraday::Utils.escape key}=#{Faraday::Utils.escape value}"
       end
 
       def camelize(str)


### PR DESCRIPTION
Cannot use shovel method with frozen strings in Ruby 2.7