### PR TITLE
Add create OCO

### DIFF
--- a/lib/binance/client/rest/endpoints.rb
+++ b/lib/binance/client/rest/endpoints.rb
@@ -22,6 +22,7 @@ module Binance
         all_orders:       'v3/allOrders',
         account:          'v3/account',
         my_trades:        'v3/myTrades',
+        oco:              'v3/order/oco',
         user_data_stream: 'v1/userDataStream',
 
         # Withdraw API Endpoints

--- a/lib/binance/client/rest/methods.rb
+++ b/lib/binance/client/rest/methods.rb
@@ -59,6 +59,9 @@ module Binance
         # #all_orders
         { name: :all_orders, client: :signed,
           action: :get, endpoint: :all_orders },
+          # #create_oco!
+        { name: :create_oco!, client: :signed,
+          action: :post, endpoint: :oco },
         # #account_info
         { name: :account_info, client: :signed,
           action: :get, endpoint: :account },

--- a/lib/binance/client/rest/methods.rb
+++ b/lib/binance/client/rest/methods.rb
@@ -59,7 +59,7 @@ module Binance
         # #all_orders
         { name: :all_orders, client: :signed,
           action: :get, endpoint: :all_orders },
-          # #create_oco!
+        #create_oco!
         { name: :create_oco!, client: :signed,
           action: :post, endpoint: :oco },
         # #account_info


### PR DESCRIPTION
Added support for creating OCO.
Example:
```
args = {symbol: "BTCUSDT, side:"sell", quantity: 0.5, price: 65000, stopPrice:55000, stopLimitPrice: 54500, stopLimitTimeInForce:"GTC"}
res = binance_client.create_oco! args
```